### PR TITLE
Attribute to control if download of artefacts should happen at redeploy

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,6 +2,7 @@ default['aps-core']['version'] = '1.6.4'
 
 default['aps-core']['nexus']['username'] = 'your-nexus-username'
 default['aps-core']['nexus']['password'] = 'your-nexus-password'
+default['aps-core']['redownload_apps'] = true
 
 # db settings for activiti properties
 default['aps-core']['db']['engine'] = 'mysql'

--- a/recipes/redeploy.rb
+++ b/recipes/redeploy.rb
@@ -5,7 +5,7 @@ service service_name do
   action :stop
 end
 
-include_recipe 'aps-core::_download_artifacts'
+include_recipe 'aps-core::_download_artifacts' if node['aps-core']['redownload_apps']
 
 template "#{tomcat_home}/lib/activiti-app.properties" do
   source 'activiti-properties.erb'


### PR DESCRIPTION
For the marketplace AMI, we dont need the redeploy recipe to redownload any artefacts. Nor can it because the databags have been removed since then which causes the chef run to fail.